### PR TITLE
Remove bcrypt dependency and store plaintext passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sistema integral de gestión empresarial desarrollado en Node.js con Express, Po
 
 - **Dashboard Ejecutivo**: Panel de control con estadísticas en tiempo real y métricas avanzadas
 - **Gestión de Empleados**: CRUD completo con 30+ empleados activos y análisis por departamentos
-- **Sistema de Autenticación**: Login seguro con bcrypt, sesiones y control de acceso basado en roles
+- **Sistema de Autenticación**: Login con sesiones y control de acceso basado en roles (hashing de contraseñas pendiente)
 - **Gestión de Usuarios**: Administración completa de 10 usuarios del sistema con diferentes roles
 - **Sistema de Inventarios**: Gestión de inventario principal y periférico con asignaciones
 - **Gestión de Vacaciones**: Sistema completo de solicitudes, aprobaciones e historial
@@ -31,7 +31,7 @@ Sistema integral de gestión empresarial desarrollado en Node.js con Express, Po
 - Historial de cambios
 
 ### 🔐 Sistema de Usuarios (10 operativos)
-- Autenticación robusta con bcrypt
+- Autenticación básica (hashing pendiente)
 - Roles: Administrador, Usuario, Supervisor
 - Control de sesiones seguras
 - Logs de acceso y actividad
@@ -165,7 +165,8 @@ Responsive: Adaptable a móviles y tablets
 Iconografía: Font Awesome + Feather Icons
 
 🔒 Seguridad Implementada
-Autenticación con bcrypt (factor 12)
+Autenticación básica (hashing pendiente)
+Actualmente las contraseñas se almacenan sin cifrar. Se añadirá hashing en futuras versiones.
 
 Sesiones seguras con express-session
 
@@ -183,7 +184,7 @@ PostgreSQL: Base de datos principal con Drizzle ORM
 
 SQLite3: Base de datos de respaldo
 
-bcryptjs: Encriptación de contraseñas
+bcryptjs: (se usará próximamente para encriptar contraseñas)
 
 express-session: Manejo de sesiones
 

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 require('dotenv').config();
 const express = require('express');
 const session = require('express-session');
-const bcrypt = require('bcryptjs');
 const path = require('path');
 const fs = require('fs');
 const Database = require('./database/config');
@@ -138,36 +137,8 @@ app.post('/api/login', async (req, res) => {
       });
     }
 
-    // Verificar password (compatible con migración)
-    let passwordValido = false;
-
-    // 1. Intentar con password hasheado (nuevo sistema)
-    if (usuario.password_hash) {
-      passwordValido = await bcrypt.compare(password, usuario.password_hash);
-    }
-
-    // 2. Si no funciona, intentar con contraseña en texto plano (sistema original)
-    if (!passwordValido && usuario.contrasena) {
-      passwordValido = (password === usuario.contrasena);
-
-      // Si es válida, migrar a hash automáticamente
-      if (passwordValido) {
-        const newHash = await bcrypt.hash(password, 10);
-        await new Promise((resolve, reject) => {
-          db.db.run(
-            'UPDATE usuarios SET password_hash = ? WHERE id = ?',
-            [newHash, usuario.id],
-            (err) => {
-              if (err) reject(err);
-              else {
-                console.log(`🔄 Contraseña migrada a hash para usuario: ${usuario.usuario}`);
-                resolve();
-              }
-            }
-          );
-        });
-      }
-    }
+    // Verificar password directamente (sin hashing por ahora)
+    const passwordValido = (password === usuario.contrasena);
 
     if (!passwordValido) {
       // Incrementar intentos fallidos
@@ -811,15 +782,12 @@ app.post('/api/usuarios', requireAuth, requireRole('administrador'), async (req,
       });
     }
 
-    // Hash de la contraseña
-    const passwordHash = await bcrypt.hash(password, 10);
-
-    // Insertar nuevo usuario
+    // Insertar nuevo usuario con contraseña sin hash
     const newUserId = await new Promise((resolve, reject) => {
       db.db.run(`
-        INSERT INTO usuarios (usuario, contrasena, password_hash, rol, nombre, email, activo, fecha_creacion)
-        VALUES (?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
-      `, [usuario, password, passwordHash, rol, nombre || null, email || null], function(err) {
+        INSERT INTO usuarios (usuario, contrasena, rol, nombre, email, activo, fecha_creacion)
+        VALUES (?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
+      `, [usuario, password, rol, nombre || null, email || null], function(err) {
         if (err) {
           console.error('❌ Error SQL creando usuario:', err);
           // Verificar si es error de usuario duplicado
@@ -925,9 +893,8 @@ app.put('/api/usuarios/:id', requireAuth, async (req, res) => {
 
     // Si se proporciona nueva contraseña
     if (password && password.trim() !== '') {
-      const passwordHash = await bcrypt.hash(password, 10);
-      updateFields.push('password_hash = ?');
-      updateValues.push(passwordHash);
+      updateFields.push('contrasena = ?');
+      updateValues.push(password);
     }
 
     updateValues.push(id);
@@ -1004,18 +971,14 @@ app.post('/api/usuarios/mass-upload', requireAuth, requireRole('administrador'),
         continue;
       }
 
-      // Hash de la contraseña
-      const passwordHash = await bcrypt.hash(usuario.password, 10);
-
       // Insertar usuario
       await new Promise((resolve, reject) => {
         db.db.run(`
-          INSERT INTO usuarios (usuario, contrasena, password_hash, rol, nombre, email, activo, fecha_creacion)
-          VALUES (?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
+          INSERT INTO usuarios (usuario, contrasena, rol, nombre, email, activo, fecha_creacion)
+          VALUES (?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
         `, [
           usuario.usuario,
           usuario.password,
-          passwordHash,
           usuario.rol,
           usuario.nombre || null,
           usuario.email || null


### PR DESCRIPTION
## Summary
- drop bcrypt usage from `server.js` and `database/config.js`
- remove `password_hash` column and migration logic
- store passwords directly when creating or updating users
- update README to note that hashing will be added later

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e3de77cc4832a90e2ae4064ebc441