### PR TITLE
Fix invalid feather icons in empleados pages

### DIFF
--- a/public/empleados.html
+++ b/public/empleados.html
@@ -782,7 +782,7 @@
             <div class="kpi-card">
                 <div class="kpi-header">
                     <div class="kpi-icon purple">
-                        <i data-feather="building"></i>
+                        <i data-feather="briefcase"></i>
                     </div>
                     <div class="kpi-title">Departamento Principal</div>
                 </div>
@@ -891,7 +891,7 @@
                             <i data-feather="user"></i> Nombre Completo
                         </th>
                         <th onclick="sortTable('departamento')">
-                            <i data-feather="building"></i> Departamento
+                            <i data-feather="briefcase"></i> Departamento
                         </th>
                         <th onclick="sortTable('email')">
                             <i data-feather="mail"></i> Email

--- a/public/empleados.js
+++ b/public/empleados.js
@@ -737,7 +737,7 @@ function verPanelCompleto() {
                         <!-- Comparativa Departamentos -->
                         <div class="form-section">
                             <div class="form-section-title">
-                                <i data-feather="git-compare"></i>
+                                <i data-feather="git-branch"></i>
                                 Comparativa entre Departamentos
                             </div>
                             <div id="comparativa-container">
@@ -996,7 +996,7 @@ function renderAnalisisDepartamentos(analisisDepartamentos) {
                     <div class="form-section-title" style="cursor: pointer; display: flex; justify-content: space-between; align-items: center;" 
                          onclick="toggleDepartamento('${deptId}')">
                         <div style="display: flex; align-items: center; gap: 0.5rem;">
-                            <i data-feather="building"></i>
+                            <i data-feather="briefcase"></i>
                             <strong>${departamento}</strong>
                         </div>
                         <div style="display: flex; gap: 1rem; align-items: center;">
@@ -1062,7 +1062,7 @@ function renderComparativa(comparativa) {
         <table class="employees-table">
             <thead>
                 <tr>
-                    <th><i data-feather="building"></i> Departamento</th>
+                    <th><i data-feather="briefcase"></i> Departamento</th>
                     <th><i data-feather="users"></i> Total Empleados</th>
                     <th><i data-feather="award"></i> Rango Predominante</th>
                     <th><i data-feather="layers"></i> Diversidad Rangos</th>


### PR DESCRIPTION
## Summary
- replace `data-feather="building"` uses with `briefcase`
- replace `data-feather="git-compare"` with `git-branch`
- icons now reload correctly via existing `feather.replace()` calls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f5a490bf0832aa5a2d1d0691291a0