### PR TITLE
Fix duplicate dashboard stylesheet

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Estilos principales -->
-    <link rel="stylesheet" href="dashboard.css">
     <link rel="stylesheet" href="shared-components.css">
     <link rel="stylesheet" href="vacaciones-styles.css">
 </head>


### PR DESCRIPTION
## Summary
- remove a duplicate CSS link reference in `dashboard.html`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f8032169c832a87258f356b4e0554