### PR TITLE
Add basic Jest setup with mocked dashboard test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -19,5 +19,9 @@
     "express-session": "^1.18.1",
     "sqlite3": "^5.1.7",
     "ws": "^8.16.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1482,21 +1482,29 @@ app.get('/api/empleado/:id', requireAuth, async (req, res) => {
     }
 });
 
-// Inicializar sistema de vacaciones después de que la base de datos esté lista
-db.connect().then(() => {
-  console.log('🎯 Sistema de base de datos inicializado correctamente');
-  return prestamos.conectar();
-}).then(() => {
-  console.log('📦 Sistema de préstamos inicializado');
-  return initializeVacacionesSystem();
-}).catch(err => {
-  console.error('❌ Error inicializando el sistema:', err);
-});
+// Inicializar sistema de vacaciones y arrancar servidor solo cuando este
+// archivo se ejecuta directamente. Esto facilita su uso en pruebas.
+if (require.main === module) {
+  db.connect()
+    .then(() => {
+      console.log('🎯 Sistema de base de datos inicializado correctamente');
+      return prestamos.conectar();
+    })
+    .then(() => {
+      console.log('📦 Sistema de préstamos inicializado');
+      return initializeVacacionesSystem();
+    })
+    .catch((err) => {
+      console.error('❌ Error inicializando el sistema:', err);
+    });
 
-// Iniciar servidor
-app.listen(PORT, '0.0.0.0', () => {
-  console.log(`🚀 Servidor Express ejecutándose en http://0.0.0.0:${PORT}`);
-  console.log('✅ Sesiones configuradas');
-  console.log('✅ Autenticación lista');
-  console.log('✅ Archivos estáticos en /public');
-});
+  // Iniciar servidor
+  app.listen(PORT, '0.0.0.0', () => {
+    console.log(`🚀 Servidor Express ejecutándose en http://0.0.0.0:${PORT}`);
+    console.log('✅ Sesiones configuradas');
+    console.log('✅ Autenticación lista');
+    console.log('✅ Archivos estáticos en /public');
+  });
+}
+
+module.exports = app;

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -1,0 +1,33 @@
+const request = require('supertest');
+
+// Mock database and prestamos modules before requiring the app
+jest.mock('../database/config', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      db: {
+        get: jest.fn((query, params, cb) => cb(null, { total: 3 })),
+        all: jest.fn()
+      },
+      connect: jest.fn(() => Promise.resolve()),
+      getUser: jest.fn(),
+      logAccess: jest.fn(),
+    };
+  });
+});
+
+jest.mock('../database/prestamos', () => {
+  return jest.fn().mockImplementation(() => ({
+    conectar: jest.fn(() => Promise.resolve()),
+  }));
+});
+
+const app = require('../server');
+
+describe('Dashboard API', () => {
+  test('GET /api/dashboard/total-empleados returns mocked total', async () => {
+    const res = await request(app).get('/api/dashboard/total-empleados');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ total: 3 });
+  });
+});
+


### PR DESCRIPTION
## Summary
- initialize Jest and Supertest as dev deps
- export Express app and conditional server startup for testing
- add Jest test for dashboard endpoint

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f82b04640832abe638ff45c4d22f5