### PR TITLE
Centralize department lists

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -545,6 +545,7 @@
     </div>
 
     <!-- Scripts principales -->
+    <script src="/departamentos-utils.js"></script>
     <script src="/dashboard.js"></script>
     <script src="/dashboard-summary.js"></script>
     <script src="vacaciones-manager.js"></script>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -11,27 +11,9 @@ let currentEditingUserId = null;
 let currentDeletingUserId = null;
 
 // Cache de departamentos para evitar solicitudes repetidas
-let departamentosCache = null;
-
-// Obtener lista de departamentos desde la API
+// Obtener lista de departamentos utilizando utilidades compartidas
 async function fetchDepartamentos() {
-    if (departamentosCache) {
-        return departamentosCache;
-    }
-    try {
-        const response = await fetch('/api/departamentos');
-        if (response.ok) {
-            const data = await response.json();
-            departamentosCache = data.departamentos || [];
-        } else {
-            console.error('Error al cargar departamentos:', response.status);
-            departamentosCache = [];
-        }
-    } catch (error) {
-        console.error('❌ Error obteniendo departamentos:', error);
-        departamentosCache = [];
-    }
-    return departamentosCache;
+    return await getDepartamentosList();
 }
 
 // Inicializar el dashboard

--- a/public/departamentos-utils.js
+++ b/public/departamentos-utils.js
@@ -1,0 +1,34 @@
+let departamentosCache = null;
+
+async function getDepartamentosList() {
+    if (departamentosCache) {
+        return departamentosCache;
+    }
+    try {
+        const response = await fetch('/api/departamentos');
+        if (response.ok) {
+            const data = await response.json();
+            departamentosCache = data.departamentos || [];
+        } else {
+            console.error('Error al cargar departamentos:', response.status);
+            departamentosCache = [];
+        }
+    } catch (error) {
+        console.error('❌ Error obteniendo departamentos:', error);
+        departamentosCache = [];
+    }
+    return departamentosCache;
+}
+
+async function generarOpcionesDepartamentos(selectedNombre = '') {
+    const departamentos = await getDepartamentosList();
+    const options = departamentos.map(dep => {
+        const selected = dep.nombre === selectedNombre ? 'selected' : '';
+        return `<option value="${dep.nombre}" ${selected}>${dep.nombre}</option>`;
+    }).join('');
+    return options;
+}
+
+// Expose functions globally
+window.getDepartamentosList = getDepartamentosList;
+window.generarOpcionesDepartamentos = generarOpcionesDepartamentos;

--- a/public/empleados.html
+++ b/public/empleados.html
@@ -1074,6 +1074,7 @@
         </div>
     </div>
 
+    <script src="departamentos-utils.js"></script>
     <script src="empleados.js"></script>
     <script>
         // Inicializar iconos de Feather

--- a/public/panel-completo.html
+++ b/public/panel-completo.html
@@ -93,6 +93,7 @@
         <div id="datosIncompletos"><p>Cargando...</p></div>
     </div>
 </main>
+<script src="/departamentos-utils.js"></script>
 <script src="/panel-completo.js"></script>
 <script>feather.replace();</script>
 </body>

--- a/public/panel-completo.js
+++ b/public/panel-completo.js
@@ -39,21 +39,20 @@ async function cargarEmpleados() {
     const res = await fetch('/api/empleados');
     empleados = await res.json();
     filtrados = [...empleados];
-    poblarFiltros();
+    await poblarFiltros();
     renderTabla();
 }
 
-function poblarFiltros() {
+async function poblarFiltros() {
     const depSelect = document.getElementById('departamentoFilter');
     const rangoSelect = document.getElementById('rangoFilter');
-    const deps = new Set();
+    const departamentos = await getDepartamentosList();
     const rangos = new Set();
     empleados.forEach(e => {
-        if (e.departamento_nombre || e.departamento) deps.add(e.departamento_nombre || e.departamento);
         if (e.rango) rangos.add(e.rango);
     });
     depSelect.innerHTML = '<option value="">Todos los departamentos</option>' +
-        Array.from(deps).map(d => `<option value="${d}">${d}</option>`).join('');
+        departamentos.map(d => `<option value="${d.nombre}">${d.nombre}</option>`).join('');
     rangoSelect.innerHTML = '<option value="">Todos los rangos</option>' +
         Array.from(rangos).map(r => `<option value="${r}">${r}</option>`).join('');
 }


### PR DESCRIPTION
## Summary
- add shared `departamentos-utils.js` helper
- load department list from the same API in dashboard and empleados pages
- update `panel-completo.js` to populate filters from API
- include new script on relevant pages

## Testing
- `npm test` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_6860bd7bdee8832aad9187ad8a573efc