### PR TITLE
Generate empleado IDs with UUIDs

### DIFF
--- a/database/config.js
+++ b/database/config.js
@@ -1,6 +1,7 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
 
 class Database {
     constructor() {
@@ -451,8 +452,8 @@ class Database {
     // Crear nuevo empleado
     createEmpleado(empleadoData) {
         return new Promise((resolve, reject) => {
-            // Generar ID único
-            const id = 'EMP' + Date.now().toString().slice(-6);
+            // Generar ID único utilizando UUID
+            const id = crypto.randomUUID();
 
             const query = `
                 INSERT INTO empleados (

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -633,7 +633,7 @@ let empleadoEnEdicion = null;
 
 // Función para editar empleado (disponible globalmente)
 window.editarEmpleado = async function editarEmpleado(empleadoId) {
-    // Usar el ID tal como viene (EMP001, EMP002, etc.)
+    // Usar el ID tal como viene
     console.log('Editando empleado ID:', empleadoId);
 
     try {
@@ -923,7 +923,7 @@ function updateEmployeesTable(empleados) {
     tbody.innerHTML = empleados.map(empleado => {
         return `
             <tr>
-                <td>${empleado.id.toString().replace('EMP', '')}</td>
+                <td>${empleado.id}</td>
                 <td><span class="placa-badge">${empleado.placa || 'Sin placa'}</span></td>
                 <td><span class="rango-badge">${empleado.rango || 'Sin rango'}</span></td>
                 <td>

--- a/public/empleados.js
+++ b/public/empleados.js
@@ -337,7 +337,7 @@ function renderEmpleados() {
 
     tbody.innerHTML = empleadosPage.map(empleado => `
         <tr>
-            <td>${empleado.id ? empleado.id.toString().replace('EMP', '') : 'N/A'}</td>
+            <td>${empleado.id || 'N/A'}</td>
             <td>
                 <span class="employee-badge badge-placa">
                     ${empleado.placa || 'Sin placa'}

--- a/server.js
+++ b/server.js
@@ -1332,7 +1332,7 @@ app.get('/api/empleados-completos', requireAuth, async (req, res) => {
                     // Añadir ID numérico a cada empleado
                     const empleadosConIdNumerico = rows.map(empleado => ({
                         ...empleado,
-                        id_numerico: parseInt(empleado.id.toString().replace('EMP', '')) || empleado.id
+                        id_numerico: parseInt(empleado.id) || empleado.id
                     }));
                     resolve(empleadosConIdNumerico);
                 }


### PR DESCRIPTION
## Summary
- use `crypto.randomUUID()` for empleado IDs
- drop `EMP` prefix assumptions in server and client code

## Testing
- `npm test --silent` *(fails: invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_6860c7dce708832a91c5bca4d448f01f