### PR TITLE
Add database control panel

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -48,6 +48,10 @@
                         <i class="fas fa-boxes"></i>
                         <span>Inventarios</span>
                     </a>
+    <a href="/panel-control" class="menu-item">
+        <i class="fas fa-database"></i>
+        <span>Panel de Control</span>
+    </a>
                 </div>
 
                 <div class="menu-section">

--- a/public/panel-control.css
+++ b/public/panel-control.css
@@ -1,0 +1,38 @@
+.pc-header {
+    background: var(--bg-primary);
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.pc-header .btn-back {
+    color: var(--text-primary);
+    text-decoration: none;
+    background: var(--glass-bg);
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius-sm);
+}
+.cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 1rem;
+    padding: 1rem;
+}
+.pc-card {
+    background: var(--glass-bg);
+    border-radius: var(--radius-md);
+    padding: 1rem;
+    text-align: center;
+    cursor: pointer;
+    transition: var(--transition-smooth);
+}
+.pc-card:hover {
+    background: var(--glass-bg-strong);
+}
+.pc-card i {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+.table-wrapper {
+    padding: 1rem;
+}

--- a/public/panel-control.html
+++ b/public/panel-control.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Panel de Control</title>
+    <link rel="stylesheet" href="/dashboard.css">
+    <link rel="stylesheet" href="/panel-control.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+</head>
+<body>
+    <header class="pc-header">
+        <h1>Panel de Control de Base de Datos</h1>
+        <a href="/dashboard" class="btn-back">Volver al Dashboard</a>
+    </header>
+    <main class="pc-main">
+        <div class="cards-grid">
+            <div class="pc-card" data-table="usuarios"><i class="fas fa-users"></i><span>Usuarios</span></div>
+            <div class="pc-card" data-table="departamentos"><i class="fas fa-building"></i><span>Departamentos</span></div>
+            <div class="pc-card" data-table="empleados"><i class="fas fa-user-tie"></i><span>Empleados</span></div>
+            <div class="pc-card" data-table="inventario_principal"><i class="fas fa-desktop"></i><span>Inventario Principal</span></div>
+            <div class="pc-card" data-table="inventario_periferico"><i class="fas fa-keyboard"></i><span>Inventario Periférico</span></div>
+            <div class="pc-card" data-table="configuracion"><i class="fas fa-cogs"></i><span>Configuración</span></div>
+            <div class="pc-card" data-table="logs_acceso"><i class="fas fa-list"></i><span>Logs de Acceso</span></div>
+            <div class="pc-card" data-table="historial_asignaciones"><i class="fas fa-history"></i><span>Historial de Asignaciones</span></div>
+        </div>
+        <div class="table-wrapper">
+            <table id="control-table" class="display" style="width:100%"></table>
+        </div>
+    </main>
+    <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="/panel-control.js"></script>
+</body>
+</html>

--- a/public/panel-control.js
+++ b/public/panel-control.js
@@ -1,0 +1,32 @@
+let dataTable;
+
+function parseRows(res) {
+    if (Array.isArray(res)) return res;
+    if (res.data && Array.isArray(res.data)) return res.data;
+    const key = Object.keys(res).find(k => Array.isArray(res[k]));
+    return key ? res[key] : [];
+}
+
+async function loadTable(tableName) {
+    try {
+        const response = await fetch(`/api/${tableName}`);
+        const result = await response.json();
+        const rows = parseRows(result);
+        const columns = rows.length
+            ? Object.keys(rows[0]).map(k => ({ title: k, data: k }))
+            : [];
+        if (dataTable) {
+            dataTable.clear().destroy();
+            document.querySelector('#control-table').innerHTML = '';
+        }
+        dataTable = $('#control-table').DataTable({ data: rows, columns });
+    } catch (err) {
+        console.error('Error cargando tabla', err);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.pc-card').forEach(card => {
+        card.addEventListener('click', () => loadTable(card.dataset.table));
+    });
+});

--- a/server.js
+++ b/server.js
@@ -187,6 +187,11 @@ app.get('/panel-completo', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'panel-completo.html'));
 });
 
+// Panel de control de tablas
+app.get('/panel-control', requireAuth, (req, res) =>
+  res.sendFile(path.join(__dirname, 'public', 'panel-control.html'))
+);
+
 // === Endpoints de Dashboard (SQLite) ===
 app.get('/api/dashboard/total-empleados', (req, res) => {
   db.db.get('SELECT COUNT(*) as total FROM empleados', [], (err, row) => {
@@ -623,6 +628,57 @@ app.get('/api/departamentos', requireAuth, async (req, res) => {
     console.error('❌ Error obteniendo departamentos:', error);
     res.status(500).json({ success: false, message: 'Error obteniendo departamentos' });
   }
+});
+
+// Endpoints de solo lectura para el panel de control
+app.get('/api/inventario_principal', requireAuth, async (req, res) => {
+  try {
+    const data = await db.getInventarioPrincipal();
+    res.json({ success: true, data });
+  } catch (error) {
+    console.error('❌ Error obteniendo inventario principal:', error);
+    res.status(500).json({ success: false, message: 'Error obteniendo inventario principal' });
+  }
+});
+
+app.get('/api/inventario_periferico', requireAuth, async (req, res) => {
+  try {
+    const data = await db.getInventarioPeriferico();
+    res.json({ success: true, data });
+  } catch (error) {
+    console.error('❌ Error obteniendo inventario periférico:', error);
+    res.status(500).json({ success: false, message: 'Error obteniendo inventario periférico' });
+  }
+});
+
+app.get('/api/configuracion', requireAuth, (req, res) => {
+  db.db.all('SELECT * FROM configuracion', [], (err, rows) => {
+    if (err) {
+      console.error('❌ Error obteniendo configuracion:', err);
+      return res.status(500).json({ success: false, message: 'Error obteniendo configuracion' });
+    }
+    res.json({ success: true, data: rows });
+  });
+});
+
+app.get('/api/logs_acceso', requireAuth, (req, res) => {
+  db.db.all('SELECT * FROM logs_acceso ORDER BY fecha DESC', [], (err, rows) => {
+    if (err) {
+      console.error('❌ Error obteniendo logs:', err);
+      return res.status(500).json({ success: false, message: 'Error obteniendo logs' });
+    }
+    res.json({ success: true, data: rows });
+  });
+});
+
+app.get('/api/historial_asignaciones', requireAuth, (req, res) => {
+  db.db.all('SELECT * FROM historial_asignaciones ORDER BY fecha_cambio DESC', [], (err, rows) => {
+    if (err) {
+      console.error('❌ Error obteniendo historial asignaciones:', err);
+      return res.status(500).json({ success: false, message: 'Error obteniendo historial asignaciones' });
+    }
+    res.json({ success: true, data: rows });
+  });
 });
 
 // Registrar préstamo de equipo


### PR DESCRIPTION
## Summary
- add link for Control panel in dashboard
- create a modern Panel de Control page
- implement DataTables viewer for table queries
- serve `/panel-control` route in Express
- expose read-only API endpoints for DB tables

## Testing
- `npm test` *(fails: invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_6860cd5b377c832ab4d970286f6cd20d