### PR TITLE
Move employee actions to panel control

### DIFF
--- a/public/empleados.html
+++ b/public/empleados.html
@@ -739,14 +739,6 @@
                     <i data-feather="bar-chart-2"></i>
                     <span>Ver Panel Completo</span>
                 </button>
-                <button class="btn-modern btn-secondary" onclick="cargaMasivaEmpleados()">
-                    <i data-feather="upload"></i>
-                    <span>Carga Masiva</span>
-                </button>
-                <button class="btn-modern btn-primary" onclick="showNuevoEmpleadoModal()">
-                    <i data-feather="user-plus"></i>
-                    <span>Agregar Empleado</span>
-                </button>
             </div>
         </div>
     </header>

--- a/public/empleados.js
+++ b/public/empleados.js
@@ -14,6 +14,11 @@ document.addEventListener('DOMContentLoaded', function() {
     console.log('🎯 Inicializando gestión moderna de empleados');
     initializeDepartmentSelectors();
     initializeApp();
+    if (window.location.hash === '#nuevo') {
+        showNuevoEmpleadoModal();
+    } else if (window.location.hash === '#massupload') {
+        cargaMasivaEmpleados();
+    }
 });
 
 // Función para inicializar selectores de departamentos

--- a/public/panel-control.css
+++ b/public/panel-control.css
@@ -36,3 +36,44 @@
 .table-wrapper {
     padding: 1rem;
 }
+
+.pc-actions {
+    display: none;
+    gap: var(--spacing-sm);
+    padding: 0 1rem 1rem;
+}
+
+.btn-modern {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    padding: 0.625rem 1rem;
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: var(--transition-fast);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.btn-primary {
+    background: var(--primary-blue);
+    color: #fff;
+}
+
+.btn-primary:hover {
+    background: var(--primary-blue-dark);
+}
+
+.btn-secondary {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-light);
+}
+
+.btn-secondary:hover {
+    background: var(--bg-hover);
+    border-color: var(--border-medium);
+}

--- a/public/panel-control.html
+++ b/public/panel-control.html
@@ -28,6 +28,16 @@
         <div class="table-wrapper">
             <table id="control-table" class="display" style="width:100%"></table>
         </div>
+        <div id="empleados-actions" class="pc-actions">
+            <button class="btn-modern btn-secondary" onclick="window.location.href='/empleados#massupload'">
+                <i class="fas fa-upload"></i>
+                <span>Carga Masiva</span>
+            </button>
+            <button class="btn-modern btn-primary" onclick="window.location.href='/empleados#nuevo'">
+                <i class="fas fa-user-plus"></i>
+                <span>Agregar Empleado</span>
+            </button>
+        </div>
     </main>
     <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>

--- a/public/panel-control.js
+++ b/public/panel-control.js
@@ -26,7 +26,15 @@ async function loadTable(tableName) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    const actions = document.getElementById('empleados-actions');
     document.querySelectorAll('.pc-card').forEach(card => {
-        card.addEventListener('click', () => loadTable(card.dataset.table));
+        card.addEventListener('click', () => {
+            loadTable(card.dataset.table);
+            if (card.dataset.table === 'empleados') {
+                actions.style.display = 'flex';
+            } else {
+                actions.style.display = 'none';
+            }
+        });
     });
 });


### PR DESCRIPTION
## Summary
- remove `Carga Masiva` and `Agregar Empleado` buttons from employee page
- show those actions in *Panel de Control* when selecting **Empleados**
- style new action buttons in panel-control CSS
- open employee modals automatically when linking with URL hash

## Testing
- `npm test` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_6862032d79f0832a84184927d52c8d72