### PR TITLE
Add 'Nuevo Usuario' action in panel control

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -390,9 +390,6 @@
                 <div id="usuarios-section" class="content-section">
                     <div class="users-header">
                         <h1 class="page-title">Gestión de Usuarios</h1>
-                        <button class="btn-primary" onclick="showNewUserModal()">
-                            <i class="fas fa-plus"></i> Nuevo Usuario
-                        </button>
                     </div>
 
                     <div class="users-controls">

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,6 +1,10 @@
 // Dashboard JavaScript - Sistema de Inventario y Control
 document.addEventListener('DOMContentLoaded', function() {
-    initializeDashboard();
+    initializeDashboard().then(() => {
+        if (window.location.hash === '#nuevo_usuario') {
+            showNewUserModal();
+        }
+    });
 });
 
 // Variables globales

--- a/public/panel-control.html
+++ b/public/panel-control.html
@@ -38,6 +38,12 @@
                 <span>Agregar Empleado</span>
             </button>
         </div>
+        <div id="usuarios-actions" class="pc-actions">
+            <button class="btn-modern btn-primary" onclick="window.location.href='/dashboard#nuevo_usuario'">
+                <i class="fas fa-user-plus"></i>
+                <span>Nuevo Usuario</span>
+            </button>
+        </div>
     </main>
     <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>

--- a/public/panel-control.js
+++ b/public/panel-control.js
@@ -26,14 +26,17 @@ async function loadTable(tableName) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const actions = document.getElementById('empleados-actions');
+    const empleadosActions = document.getElementById('empleados-actions');
+    const usuariosActions = document.getElementById('usuarios-actions');
     document.querySelectorAll('.pc-card').forEach(card => {
         card.addEventListener('click', () => {
             loadTable(card.dataset.table);
-            if (card.dataset.table === 'empleados') {
-                actions.style.display = 'flex';
-            } else {
-                actions.style.display = 'none';
+
+            if (empleadosActions) {
+                empleadosActions.style.display = card.dataset.table === 'empleados' ? 'flex' : 'none';
+            }
+            if (usuariosActions) {
+                usuariosActions.style.display = card.dataset.table === 'usuarios' ? 'flex' : 'none';
             }
         });
     });


### PR DESCRIPTION
## Summary
- remove 'Nuevo Usuario' button from dashboard
- show new user modal when opening dashboard with `#nuevo_usuario`
- add actions area for usuarios in panel control
- toggle action areas depending on selected card

## Testing
- `npm test` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_6862049929d4832a9dbc1b6d8cfa1b3c