### PR TITLE
Add departamento CRUD and UI actions

### DIFF
--- a/database/config.js
+++ b/database/config.js
@@ -355,6 +355,49 @@ class Database {
         });
     }
 
+    // Crear nuevo departamento
+    createDepartamento(nombre) {
+        return new Promise((resolve, reject) => {
+            const id = crypto.randomUUID();
+            const query = 'INSERT INTO departamentos (id, nombre) VALUES (?, ?)';
+            this.db.run(query, [id, nombre], function(err) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve({ id });
+                }
+            });
+        });
+    }
+
+    // Actualizar departamento existente
+    updateDepartamento(id, nombre) {
+        return new Promise((resolve, reject) => {
+            const query = 'UPDATE departamentos SET nombre = ? WHERE id = ?';
+            this.db.run(query, [nombre, id], function(err) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve({ changes: this.changes });
+                }
+            });
+        });
+    }
+
+    // Eliminar departamento
+    deleteDepartamento(id) {
+        return new Promise((resolve, reject) => {
+            const query = 'DELETE FROM departamentos WHERE id = ?';
+            this.db.run(query, [id], function(err) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve({ changes: this.changes });
+                }
+            });
+        });
+    }
+
     // Obtener inventario principal completo (estructura real)
     getInventarioPrincipal() {
         return new Promise((resolve, reject) => {

--- a/public/panel-control.css
+++ b/public/panel-control.css
@@ -77,3 +77,16 @@
     background: var(--bg-hover);
     border-color: var(--border-medium);
 }
+
+.table-actions i {
+    cursor: pointer;
+    margin: 0 0.25rem;
+}
+
+.table-actions .edit-depto {
+    color: var(--primary-color);
+}
+
+.table-actions .delete-depto {
+    color: var(--error-color);
+}

--- a/public/panel-control.html
+++ b/public/panel-control.html
@@ -38,6 +38,12 @@
                 <span>Agregar Empleado</span>
             </button>
         </div>
+        <div id="departamentos-actions" class="pc-actions">
+            <button class="btn-modern btn-primary" id="btn-add-departamento">
+                <i class="fas fa-plus"></i>
+                <span>Agregar Nuevo Departamento</span>
+            </button>
+        </div>
         <div id="usuarios-actions" class="pc-actions">
             <button class="btn-modern btn-primary" onclick="window.location.href='/dashboard#nuevo_usuario'">
                 <i class="fas fa-user-plus"></i>

--- a/public/panel-control.js
+++ b/public/panel-control.js
@@ -12,14 +12,33 @@ async function loadTable(tableName) {
         const response = await fetch(`/api/${tableName}`);
         const result = await response.json();
         const rows = parseRows(result);
-        const columns = rows.length
+        let columns = rows.length
             ? Object.keys(rows[0]).map(k => ({ title: k, data: k }))
             : [];
+
+        if (tableName === 'departamentos') {
+            columns.push({
+                title: 'Acciones',
+                data: null,
+                orderable: false,
+                render: (_, __, row) => {
+                    return `
+                        <div class="table-actions">
+                            <i class="fas fa-edit edit-depto" data-id="${row.id}" data-nombre="${row.nombre}"></i>
+                            <i class="fas fa-trash delete-depto" data-id="${row.id}"></i>
+                        </div>`;
+                }
+            });
+        }
         if (dataTable) {
             dataTable.clear().destroy();
             document.querySelector('#control-table').innerHTML = '';
         }
         dataTable = $('#control-table').DataTable({ data: rows, columns });
+
+        if (tableName === 'departamentos') {
+            addDepartamentoListeners();
+        }
     } catch (err) {
         console.error('Error cargando tabla', err);
     }
@@ -28,6 +47,12 @@ async function loadTable(tableName) {
 document.addEventListener('DOMContentLoaded', () => {
     const empleadosActions = document.getElementById('empleados-actions');
     const usuariosActions = document.getElementById('usuarios-actions');
+    const departamentosActions = document.getElementById('departamentos-actions');
+    const btnAddDepartamento = document.getElementById('btn-add-departamento');
+
+    if (btnAddDepartamento) {
+        btnAddDepartamento.addEventListener('click', crearDepartamento);
+    }
     document.querySelectorAll('.pc-card').forEach(card => {
         card.addEventListener('click', () => {
             loadTable(card.dataset.table);
@@ -38,6 +63,48 @@ document.addEventListener('DOMContentLoaded', () => {
             if (usuariosActions) {
                 usuariosActions.style.display = card.dataset.table === 'usuarios' ? 'flex' : 'none';
             }
+            if (departamentosActions) {
+                departamentosActions.style.display = card.dataset.table === 'departamentos' ? 'flex' : 'none';
+            }
         });
     });
 });
+
+function addDepartamentoListeners() {
+    $('#control-table').off('click', '.edit-depto');
+    $('#control-table').off('click', '.delete-depto');
+
+    $('#control-table').on('click', '.edit-depto', async function() {
+        const id = this.dataset.id;
+        const nombreActual = this.dataset.nombre || '';
+        const nuevoNombre = prompt('Nuevo nombre del departamento:', nombreActual);
+        if (nuevoNombre && nuevoNombre.trim() !== '') {
+            await fetch(`/api/departamentos/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ nombre: nuevoNombre.trim() })
+            });
+            loadTable('departamentos');
+        }
+    });
+
+    $('#control-table').on('click', '.delete-depto', async function() {
+        const id = this.dataset.id;
+        const confirmId = prompt(`Escriba el ID ${id} para confirmar eliminación:`);
+        if (confirmId === id) {
+            await fetch(`/api/departamentos/${id}`, { method: 'DELETE' });
+            loadTable('departamentos');
+        }
+    });
+}
+
+async function crearDepartamento() {
+    const nombre = prompt('Nombre del nuevo departamento:');
+    if (!nombre || nombre.trim() === '') return;
+    await fetch('/api/departamentos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nombre: nombre.trim() })
+    });
+    loadTable('departamentos');
+}

--- a/server.js
+++ b/server.js
@@ -630,6 +630,60 @@ app.get('/api/departamentos', requireAuth, async (req, res) => {
   }
 });
 
+// Crear departamento
+app.post('/api/departamentos', requireAuth, async (req, res) => {
+  const { nombre } = req.body;
+
+  if (!nombre) {
+    return res.status(400).json({ success: false, message: 'Nombre de departamento es requerido' });
+  }
+
+  try {
+    const resultado = await db.createDepartamento(nombre);
+    res.status(201).json({ success: true, message: 'Departamento creado', departamentoId: resultado.id });
+  } catch (error) {
+    console.error('❌ Error creando departamento:', error);
+    res.status(500).json({ success: false, message: 'Error creando departamento' });
+  }
+});
+
+// Actualizar departamento
+app.put('/api/departamentos/:id', requireAuth, async (req, res) => {
+  const { id } = req.params;
+  const { nombre } = req.body;
+
+  if (!nombre) {
+    return res.status(400).json({ success: false, message: 'Nombre de departamento es requerido' });
+  }
+
+  try {
+    const resultado = await db.updateDepartamento(id, nombre);
+    if (resultado.changes === 0) {
+      return res.status(404).json({ success: false, message: 'Departamento no encontrado' });
+    }
+    res.json({ success: true, message: 'Departamento actualizado' });
+  } catch (error) {
+    console.error('❌ Error actualizando departamento:', error);
+    res.status(500).json({ success: false, message: 'Error actualizando departamento' });
+  }
+});
+
+// Eliminar departamento
+app.delete('/api/departamentos/:id', requireAuth, async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const resultado = await db.deleteDepartamento(id);
+    if (resultado.changes === 0) {
+      return res.status(404).json({ success: false, message: 'Departamento no encontrado' });
+    }
+    res.json({ success: true, message: 'Departamento eliminado' });
+  } catch (error) {
+    console.error('❌ Error eliminando departamento:', error);
+    res.status(500).json({ success: false, message: 'Error eliminando departamento' });
+  }
+});
+
 // Endpoints de solo lectura para el panel de control
 app.get('/api/inventario_principal', requireAuth, async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- add create/update/delete methods for departamentos in DB layer
- expose POST, PUT and DELETE routes for departamentos
- enhance panel-control with actions for managing departments
- allow editing/deleting departments via table icons
- style new actions

## Testing
- `npm test` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_686205cfe294832aafe1a005b5c28c8c