### PR TITLE
Fix DataTable initialization

### DIFF
--- a/public/panel-control.js
+++ b/public/panel-control.js
@@ -30,9 +30,9 @@ async function loadTable(tableName) {
                 }
             });
         }
-        if (dataTable) {
-            dataTable.clear().destroy();
-            document.querySelector('#control-table').innerHTML = '';
+        if ($.fn.dataTable.isDataTable('#control-table')) {
+            $('#control-table').DataTable().clear().destroy();
+            $('#control-table').empty();
         }
         dataTable = $('#control-table').DataTable({ data: rows, columns });
 


### PR DESCRIPTION
## Summary
- clear existing DataTable with `$.fn.dataTable.isDataTable()` before creating a new one

## Testing
- `npm test` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_6862074c2a4c832aa98f981e2ca93ab9