### PR TITLE
Join principal and peripheral inventory

### DIFF
--- a/database/config.js
+++ b/database/config.js
@@ -454,6 +454,48 @@ class Database {
         });
     }
 
+    // Obtener inventario principal junto con periféricos asociados
+    getInventarioCompleto() {
+        return new Promise((resolve, reject) => {
+            const query = `
+                SELECT ip.*,
+                       COALESCE(json_group_array(
+                           json_object(
+                               'id_periferico', iph.id_periferico,
+                               'nombre_periferico', iph.nombre_periferico,
+                               'marca_periferico', iph.marca_periferico,
+                               'modelo_periferico', iph.modelo_periferico,
+                               'serie_periferico', iph.serie_periferico,
+                               'estado_periferico', iph.estado_periferico,
+                               'condicion_periferico', iph.condicion_periferico,
+                               'tipo_adquisicion_periferico', iph.tipo_adquisicion_periferico,
+                               'id_departamento_asignado_periferico', iph.id_departamento_asignado_periferico,
+                               'ubicacion_especifica_periferico', iph.ubicacion_especifica_periferico,
+                               'responsable_actual_periferico', iph.responsable_actual_periferico,
+                               'fecha_creacion_periferico', iph.fecha_creacion_periferico,
+                               'fecha_adquisicion_periferico', iph.fecha_adquisicion_periferico,
+                               'detalles_periferico', iph.detalles_periferico
+                           )
+                       ), '[]') AS perifericos
+                FROM inventario_principal ip
+                LEFT JOIN inventario_periferico iph ON iph.id_inventario_principal = ip.id
+                GROUP BY ip.id
+                ORDER BY ip.fecha_adquisicion DESC, ip.nombre
+            `;
+
+            this.db.all(query, (err, rows) => {
+                if (err) reject(err);
+                else {
+                    const formatted = rows.map(row => ({
+                        ...row,
+                        perifericos: row.perifericos ? JSON.parse(row.perifericos) : []
+                    }));
+                    resolve(formatted);
+                }
+            });
+        });
+    }
+
     getEmpleados() {
         return new Promise((resolve, reject) => {
             const query = `

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -389,17 +389,16 @@ function closeConfirmModal() {
 // Cargar datos de inventario
 async function loadInventoryData() {
     try {
-        const [principalResponse, perifericoResponse] = await Promise.all([
-            fetch('/api/inventario-principal'),
-            fetch('/api/inventario-periferico')
-        ]);
+        const response = await fetch('/api/inventario-completo');
 
-        if (principalResponse.ok && perifericoResponse.ok) {
-            const principalData = await principalResponse.json();
-            const perifericoData = await perifericoResponse.json();
+        if (response.ok) {
+            const data = await response.json();
+
+            const principalData = data.inventario || [];
+            const perifericoData = principalData.flatMap(item => item.perifericos || []);
 
             // Actualizar contadores del dashboard
-            updateInventoryCounters(principalData.inventario, perifericoData.inventario);
+            updateInventoryCounters(principalData, perifericoData);
         }
     } catch (error) {
         console.error('❌ Error cargando inventario:', error);

--- a/server.js
+++ b/server.js
@@ -619,6 +619,17 @@ app.get('/api/inventario-periferico', requireAuth, async (req, res) => {
   }
 });
 
+// Obtener inventario completo con periféricos asociados
+app.get('/api/inventario-completo', requireAuth, async (req, res) => {
+  try {
+    const inventario = await db.getInventarioCompleto();
+    res.json({ success: true, inventario });
+  } catch (error) {
+    console.error('❌ Error obteniendo inventario completo:', error);
+    res.status(500).json({ success: false, message: 'Error obteniendo inventario completo' });
+  }
+});
+
 // Obtener departamentos
 app.get('/api/departamentos', requireAuth, async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- aggregate peripherals with each principal item via new `getInventarioCompleto`
- expose new `/api/inventario-completo` route
- query the new route on the dashboard to combine counts

## Testing
- `npm test` *(fails: invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_6862082eb4e8832abb4e68fbd4176a9f