### PR TITLE
Add validations and DB transactions

### DIFF
--- a/database/config.js
+++ b/database/config.js
@@ -712,6 +712,25 @@ class Database {
         });
     }
 
+    // Transaction helpers
+    beginTransaction() {
+        return new Promise((resolve, reject) => {
+            this.db.run('BEGIN TRANSACTION', err => (err ? reject(err) : resolve()));
+        });
+    }
+
+    commitTransaction() {
+        return new Promise((resolve, reject) => {
+            this.db.run('COMMIT', err => (err ? reject(err) : resolve()));
+        });
+    }
+
+    rollbackTransaction() {
+        return new Promise((resolve, reject) => {
+            this.db.run('ROLLBACK', err => (err ? reject(err) : resolve()));
+        });
+    }
+
     close() {
         if (this.db) {
             this.db.close((err) => {


### PR DESCRIPTION
## Summary
- add SQLite transaction helpers
- validate data and uniqueness when creating/updating employees, users, and departments
- wrap changes in database transactions and provide detailed error messages

## Testing
- `npm test` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_6862093bfe5c832a87bf2decf8eb4c9e