### PR TITLE
Add employee modals to panel control

### DIFF
--- a/public/empleados.js
+++ b/public/empleados.js
@@ -14,11 +14,6 @@ document.addEventListener('DOMContentLoaded', function() {
     console.log('🎯 Inicializando gestión moderna de empleados');
     initializeDepartmentSelectors();
     initializeApp();
-    if (window.location.hash === '#nuevo') {
-        showNuevoEmpleadoModal();
-    } else if (window.location.hash === '#massupload') {
-        cargaMasivaEmpleados();
-    }
 });
 
 // Función para inicializar selectores de departamentos

--- a/public/panel-control.html
+++ b/public/panel-control.html
@@ -29,11 +29,11 @@
             <table id="control-table" class="display" style="width:100%"></table>
         </div>
         <div id="empleados-actions" class="pc-actions">
-            <button class="btn-modern btn-secondary" onclick="window.location.href='/empleados.html#massupload'">
+            <button class="btn-modern btn-secondary" onclick="showMassUploadModal()">
                 <i class="fas fa-upload"></i>
                 <span>Carga Masiva</span>
             </button>
-            <button class="btn-modern btn-primary" onclick="window.location.href='/empleados.html#nuevo'">
+            <button class="btn-modern btn-primary" onclick="showNuevoEmpleadoModal()">
                 <i class="fas fa-user-plus"></i>
                 <span>Agregar Empleado</span>
             </button>
@@ -159,9 +159,112 @@
                 </div>
             </div>
         </div>
+
+        <!-- Modal de Empleado (creación rápida) -->
+        <div id="empleado-modal" class="modal" style="display:none;">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <div class="modal-title" id="modal-title">
+                        <i data-feather="user-plus"></i>
+                        Agregar Empleado
+                    </div>
+                    <button class="modal-close" onclick="closeEmpleadoModal()">
+                        <i data-feather="x"></i>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <form id="empleado-form" class="form-grid" onsubmit="event.preventDefault(); saveEmpleado();">
+                        <div class="form-section">
+                            <div class="form-section-title">
+                                <i data-feather="user"></i>
+                                Información Personal
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label class="form-label">Nombre *</label>
+                                    <input type="text" class="form-input" name="nombre" required>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">Apellido *</label>
+                                    <input type="text" class="form-input" name="apellido" required>
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label class="form-label">Cédula</label>
+                                    <input type="text" class="form-input" name="cedula">
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">Fecha de Nacimiento</label>
+                                    <input type="date" class="form-input" name="fecha_nacimiento">
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label class="form-label">Email *</label>
+                                    <input type="email" class="form-input" name="correo_electronico" required>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">Teléfono</label>
+                                    <input type="tel" class="form-input" name="telefono">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-section">
+                            <div class="form-section-title">
+                                <i data-feather="briefcase"></i>
+                                Información Laboral
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label class="form-label">Placa</label>
+                                    <input type="text" class="form-input" name="placa">
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">Rango *</label>
+                                    <select class="form-select" name="rango" required>
+                                        <option value="">Seleccionar rango</option>
+                                        <option value="AGENTE">AGENTE</option>
+                                        <option value="CABO 2DO.">CABO 2DO.</option>
+                                        <option value="CABO 1RO.">CABO 1RO.</option>
+                                        <option value="SGTO. 2DO.">SGTO. 2DO.</option>
+                                        <option value="SGTO. 1RO.">SGTO. 1RO.</option>
+                                        <option value="SUBTENIENTE">SUBTENIENTE</option>
+                                        <option value="TENIENTE">TENIENTE</option>
+                                        <option value="CAPITÁN">CAPITÁN</option>
+                                        <option value="MAYOR">MAYOR</option>
+                                        <option value="SUBCOMISIONADO">SUBCOMISIONADO</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Departamento *</label>
+                                <select class="form-select" name="departamento" required>
+                                    <option value="">Seleccionar departamento</option>
+                                </select>
+                            </div>
+                        </div>
+                        <input type="hidden" name="id" id="empleado-id">
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn-modern btn-cancel" type="button" onclick="closeEmpleadoModal()">
+                        <i data-feather="x"></i>
+                        Cancelar
+                    </button>
+                    <button class="btn-modern btn-save" type="submit" form="empleado-form">
+                        <i data-feather="save"></i>
+                        Guardar Empleado
+                    </button>
+                </div>
+            </div>
+        </div>
     </main>
     <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://unpkg.com/feather-icons"></script>
+    <script src="/departamentos-utils.js"></script>
     <script src="/panel-control.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- open employee modals from panel-control instead of redirecting
- add quick employee creation modal HTML
- implement employee modal logic and mass upload in panel-control.js
- remove URL hash handling from empleados.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686331d06798832abfb39035bbba8cfe