### PR TITLE
Add test for /empleados route

### DIFF
--- a/tests/empleados_route.test.js
+++ b/tests/empleados_route.test.js
@@ -1,0 +1,34 @@
+const request = require('supertest');
+
+// Mock database and other dependencies
+jest.mock('../database/config', () => {
+  return jest.fn().mockImplementation(() => ({
+    db: { get: jest.fn(), all: jest.fn() },
+    connect: jest.fn(() => Promise.resolve()),
+    getUser: jest.fn(),
+    logAccess: jest.fn(),
+  }));
+});
+
+jest.mock('../database/prestamos', () => {
+  return jest.fn().mockImplementation(() => ({
+    conectar: jest.fn(() => Promise.resolve()),
+  }));
+});
+
+jest.mock('../database/vacaciones', () => {
+  return jest.fn().mockImplementation(() => ({
+    actualizarEstadosVacaciones: jest.fn(),
+  }));
+});
+
+const app = require('../server');
+// Provide default session so requireAuth passes
+app.request.session = { user: { id: 'test', rol: 'admin' } };
+
+describe('Empleado interface route', () => {
+  test('GET /empleados returns the empleados page', async () => {
+    const res = await request(app).get('/empleados');
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add automated test verifying GET /empleados returns 200

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68633c314234832a8eefb4ffc1473ae8