### PR TITLE
Add bcrypt password hashing

### DIFF
--- a/database/migrate_hash_passwords.js
+++ b/database/migrate_hash_passwords.js
@@ -1,0 +1,45 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+const fs = require('fs');
+const bcrypt = require('bcryptjs');
+
+const assetsDir = path.join(__dirname, '../attached_assets');
+if (!fs.existsSync(assetsDir)) {
+  fs.mkdirSync(assetsDir, { recursive: true });
+}
+const dbPath = path.join(assetsDir, 'kilo.db');
+
+async function migrate() {
+  const db = new sqlite3.Database(dbPath);
+
+  const users = await new Promise((resolve, reject) => {
+    db.all('SELECT id, contrasena FROM usuarios', (err, rows) => {
+      if (err) reject(err); else resolve(rows);
+    });
+  });
+
+  for (const user of users) {
+    const pass = user.contrasena || '';
+    if (!pass.startsWith('$2a$') && !pass.startsWith('$2b$') && !pass.startsWith('$2y$')) {
+      const hash = await bcrypt.hash(pass, 10);
+      await new Promise((resolve, reject) => {
+        db.run('UPDATE usuarios SET contrasena = ? WHERE id = ?', [hash, user.id], err => {
+          if (err) reject(err); else resolve();
+        });
+      });
+      console.log(`Hashed password for user ${user.id}`);
+    }
+  }
+
+  db.close();
+}
+
+if (require.main === module) {
+  migrate().then(() => {
+    console.log('Migración de contraseñas completada');
+  }).catch(err => {
+    console.error('Error en migración:', err);
+  });
+}
+
+module.exports = migrate;

--- a/tests/usuarios.test.js
+++ b/tests/usuarios.test.js
@@ -1,0 +1,62 @@
+const request = require('supertest');
+const bcrypt = require('bcryptjs');
+
+const mockDbGet = jest.fn((q, p, cb) => cb(null, null));
+let insertedPassword;
+const mockDbRun = jest.fn(function(q, params, cb){
+  insertedPassword = params[1];
+  cb.call({ lastID: 1 }, null);
+});
+const mockBeginTransaction = jest.fn(() => Promise.resolve());
+const mockCommitTransaction = jest.fn(() => Promise.resolve());
+const mockRollbackTransaction = jest.fn(() => Promise.resolve());
+const mockLogAccess = jest.fn(() => Promise.resolve());
+
+jest.mock('../database/config', () => {
+  return jest.fn().mockImplementation(() => ({
+    db: { get: mockDbGet, run: mockDbRun, all: jest.fn() },
+    connect: jest.fn(() => Promise.resolve()),
+    beginTransaction: mockBeginTransaction,
+    commitTransaction: mockCommitTransaction,
+    rollbackTransaction: mockRollbackTransaction,
+    getUser: jest.fn(),
+    logAccess: mockLogAccess,
+  }));
+});
+
+jest.mock('../database/prestamos', () => {
+  return jest.fn().mockImplementation(() => ({
+    conectar: jest.fn(() => Promise.resolve()),
+  }));
+});
+
+jest.mock('../database/vacaciones', () => {
+  return jest.fn().mockImplementation(() => ({
+    actualizarEstadosVacaciones: jest.fn(),
+  }));
+});
+
+const app = require('../server');
+app.request.session = { user: { id: 'admin', rol: 'administrador' } };
+
+describe('User creation', () => {
+  beforeEach(() => {
+    insertedPassword = undefined;
+    jest.clearAllMocks();
+  });
+
+  test('password is hashed before saving', async () => {
+    const res = await request(app)
+      .post('/api/usuarios')
+      .send({ usuario: 'newuser', password: 'secret', rol: 'administrador' });
+
+    expect(res.status).toBe(200);
+    expect(mockBeginTransaction).toHaveBeenCalled();
+    expect(mockCommitTransaction).toHaveBeenCalled();
+    expect(insertedPassword).toBeDefined();
+    expect(insertedPassword).not.toBe('secret');
+    expect(insertedPassword.startsWith('$2')).toBe(true);
+    const match = await bcrypt.compare('secret', insertedPassword);
+    expect(match).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- hash passwords with bcrypt on user creation
- verify login passwords using bcrypt.compare
- hash new password on user update
- provide migration script to hash existing passwords
- test password hashing when creating users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68633fc8c3ec832aba8ed97e6ea30abe