### PR TITLE
Add DuckDB Node API dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "python-shell": "^5.0.0",
         "sqlite3": "^5.1.7",
         "superagent": "^10.2.1",
-        "ws": "^8.16.0"
+        "ws": "^8.16.0",
+        "@duckdb/node-api": "^0.10.0"
       },
       "devDependencies": {
         "cross-env": "^7.0.3",
@@ -7032,6 +7033,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@duckdb/node-api": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-0.10.0.tgz",
+      "integrity": "",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "python-shell": "^5.0.0",
     "sqlite3": "^5.1.7",
     "superagent": "^10.2.1",
-    "ws": "^8.16.0"
+    "ws": "^8.16.0",
+    "@duckdb/node-api": "^0.10.0"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",


### PR DESCRIPTION
## Summary
- include `@duckdb/node-api` dependency
- update lockfile (manual)

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails to find jest-environment-jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_6864dbaa448c832a9ab4602c6437ac00