### PR TITLE
Initialize DuckDB

### DIFF
--- a/database/duckdb.js
+++ b/database/duckdb.js
@@ -1,0 +1,116 @@
+const duckdb = require('@duckdb/node-api');
+const path = require('path');
+require('dotenv').config();
+
+const dbPath =
+  process.env.DUCKDB_PATH ||
+  path.join(__dirname, '../attached_assets/analytics.db');
+
+// Create DuckDB database and connection
+const db = new duckdb.Database(dbPath);
+const connection = db.connect();
+
+async function createInventoryTables() {
+  const statements = [
+    `CREATE TABLE IF NOT EXISTS usuarios (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        usuario TEXT UNIQUE NOT NULL,
+        contrasena TEXT NOT NULL,
+        rol TEXT DEFAULT 'no administrador',
+        nombre TEXT,
+        apellido TEXT,
+        email TEXT,
+        telefono TEXT,
+        activo BOOLEAN DEFAULT 1,
+        fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        ultimo_acceso TIMESTAMP,
+        intentos_fallidos INTEGER DEFAULT 0,
+        bloqueado_hasta TIMESTAMP
+    )`,
+    `CREATE TABLE IF NOT EXISTS departamentos (
+        id TEXT PRIMARY KEY,
+        nombre TEXT NOT NULL
+    )`,
+    `CREATE TABLE IF NOT EXISTS empleados (
+        id TEXT PRIMARY KEY,
+        placa TEXT UNIQUE,
+        rango TEXT,
+        nombre TEXT,
+        apellido TEXT,
+        departamento_id TEXT,
+        correo_electronico TEXT,
+        cedula TEXT UNIQUE,
+        telefono TEXT,
+        fecha_ingreso DATE,
+        fecha_nacimiento DATE,
+        fecha_vacaciones_inicio DATE,
+        fecha_vacaciones_fin DATE,
+        responsable_actual TEXT,
+        fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        fecha_adquisicion TIMESTAMP,
+        detalles TEXT,
+        activo BOOLEAN DEFAULT 1,
+        FOREIGN KEY (departamento_id) REFERENCES departamentos(id),
+        FOREIGN KEY (responsable_actual) REFERENCES empleados(id)
+    )`,
+    `CREATE TABLE IF NOT EXISTS inventario_periferico (
+        id_periferico TEXT PRIMARY KEY,
+        nombre_periferico TEXT,
+        marca_periferico TEXT,
+        modelo_periferico TEXT,
+        serie_periferico TEXT,
+        estado_periferico TEXT DEFAULT 'operativo',
+        condicion_periferico TEXT DEFAULT 'nuevo',
+        tipo_adquisicion_periferico TEXT,
+        id_departamento_asignado_periferico TEXT,
+        ubicacion_especifica_periferico TEXT,
+        responsable_actual_periferico TEXT,
+        fecha_creacion_periferico TEXT,
+        fecha_adquisicion_periferico TEXT,
+        detalles_periferico TEXT,
+        id_inventario_principal TEXT,
+        fecha_asignacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (id_departamento_asignado_periferico) REFERENCES departamentos(id),
+        FOREIGN KEY (responsable_actual_periferico) REFERENCES empleados(id),
+        FOREIGN KEY (id_inventario_principal) REFERENCES inventario_principal(id)
+    )`,
+    `CREATE TABLE IF NOT EXISTS inventario_principal (
+        id TEXT PRIMARY KEY,
+        nombre TEXT,
+        marca TEXT,
+        modelo TEXT,
+        serie TEXT,
+        categoria TEXT,
+        subcategoria TEXT,
+        estado TEXT DEFAULT 'operativo',
+        condicion TEXT DEFAULT 'nuevo',
+        tipo_adquisicion TEXT,
+        id_departamento_asignado TEXT,
+        ubicacion_especifica TEXT,
+        responsable_actual TEXT,
+        fecha_creacion TEXT,
+        fecha_adquisicion TEXT,
+        detalles TEXT,
+        ubicacion TEXT,
+        valor_compra DECIMAL(10,2),
+        proveedor TEXT,
+        garantia_hasta DATE,
+        FOREIGN KEY (id_departamento_asignado) REFERENCES departamentos(id),
+        FOREIGN KEY (responsable_actual) REFERENCES empleados(id)
+    )`,
+  ];
+
+  for (const sql of statements) {
+    await new Promise((resolve, reject) => {
+      connection.run(sql, (err) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  }
+}
+
+module.exports = {
+  connection,
+  createInventoryTables,
+};

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const http = require('http');
 const WebSocket = require('ws');
 const Database = require('./database/config');
 const VacacionesManager = require('./database/vacaciones');
+const analyticsDB = require('./database/duckdb');
 
 let wss; // WebSocket server (solo cuando se ejecuta directamente)
 
@@ -379,12 +380,10 @@ app.get('/api/equipos-disponibles', requireAuth, async (req, res) => {
     res.json({ success: true, equipos });
   } catch (error) {
     console.error('❌ Error obteniendo equipos disponibles:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error obteniendo equipos disponibles',
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error obteniendo equipos disponibles',
+    });
   }
 });
 
@@ -648,23 +647,19 @@ app.post('/api/empleados', requireAuth, async (req, res) => {
     const resultado = await db.createEmpleado(empleadoData);
     await db.commitTransaction();
     broadcast('employees-changed');
-    res
-      .status(201)
-      .json({
-        success: true,
-        message: 'Empleado creado exitosamente',
-        empleadoId: resultado.id,
-      });
+    res.status(201).json({
+      success: true,
+      message: 'Empleado creado exitosamente',
+      empleadoId: resultado.id,
+    });
   } catch (error) {
     await db.rollbackTransaction();
     console.error('❌ Error creando empleado:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error creando empleado',
-        details: error.message,
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error creando empleado',
+      details: error.message,
+    });
   }
 });
 
@@ -745,13 +740,11 @@ app.put('/api/empleados/:id', requireAuth, async (req, res) => {
   } catch (error) {
     await db.rollbackTransaction();
     console.error('❌ Error actualizando empleado:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error actualizando empleado',
-        details: error.message,
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error actualizando empleado',
+      details: error.message,
+    });
   }
 });
 
@@ -840,12 +833,10 @@ app.get('/api/inventario-principal', requireAuth, async (req, res) => {
     res.json({ success: true, inventario });
   } catch (error) {
     console.error('❌ Error obteniendo inventario principal:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error obteniendo inventario principal',
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error obteniendo inventario principal',
+    });
   }
 });
 
@@ -856,12 +847,10 @@ app.get('/api/inventario-periferico', requireAuth, async (req, res) => {
     res.json({ success: true, inventario });
   } catch (error) {
     console.error('❌ Error obteniendo inventario periférico:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error obteniendo inventario periférico',
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error obteniendo inventario periférico',
+    });
   }
 });
 
@@ -872,12 +861,10 @@ app.get('/api/inventario-completo', requireAuth, async (req, res) => {
     res.json({ success: true, inventario });
   } catch (error) {
     console.error('❌ Error obteniendo inventario completo:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error obteniendo inventario completo',
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error obteniendo inventario completo',
+    });
   }
 });
 
@@ -899,12 +886,10 @@ app.post('/api/departamentos', requireAuth, async (req, res) => {
   const { nombre } = req.body;
 
   if (!nombre || typeof nombre !== 'string') {
-    return res
-      .status(400)
-      .json({
-        success: false,
-        message: 'Nombre de departamento es requerido y debe ser texto',
-      });
+    return res.status(400).json({
+      success: false,
+      message: 'Nombre de departamento es requerido y debe ser texto',
+    });
   }
 
   try {
@@ -929,23 +914,19 @@ app.post('/api/departamentos', requireAuth, async (req, res) => {
     const resultado = await db.createDepartamento(nombre);
     await db.commitTransaction();
 
-    res
-      .status(201)
-      .json({
-        success: true,
-        message: 'Departamento creado',
-        departamentoId: resultado.id,
-      });
+    res.status(201).json({
+      success: true,
+      message: 'Departamento creado',
+      departamentoId: resultado.id,
+    });
   } catch (error) {
     await db.rollbackTransaction();
     console.error('❌ Error creando departamento:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error creando departamento',
-        details: error.message,
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error creando departamento',
+      details: error.message,
+    });
   }
 });
 
@@ -955,12 +936,10 @@ app.put('/api/departamentos/:id', requireAuth, async (req, res) => {
   const { nombre } = req.body;
 
   if (!nombre || typeof nombre !== 'string') {
-    return res
-      .status(400)
-      .json({
-        success: false,
-        message: 'Nombre de departamento es requerido y debe ser texto',
-      });
+    return res.status(400).json({
+      success: false,
+      message: 'Nombre de departamento es requerido y debe ser texto',
+    });
   }
 
   try {
@@ -993,13 +972,11 @@ app.put('/api/departamentos/:id', requireAuth, async (req, res) => {
   } catch (error) {
     await db.rollbackTransaction();
     console.error('❌ Error actualizando departamento:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error actualizando departamento',
-        details: error.message,
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error actualizando departamento',
+      details: error.message,
+    });
   }
 });
 
@@ -1030,12 +1007,10 @@ app.get('/api/inventario_principal', requireAuth, async (req, res) => {
     res.json({ success: true, data });
   } catch (error) {
     console.error('❌ Error obteniendo inventario principal:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error obteniendo inventario principal',
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error obteniendo inventario principal',
+    });
   }
 });
 
@@ -1045,12 +1020,10 @@ app.get('/api/inventario_periferico', requireAuth, async (req, res) => {
     res.json({ success: true, data });
   } catch (error) {
     console.error('❌ Error obteniendo inventario periférico:', error);
-    res
-      .status(500)
-      .json({
-        success: false,
-        message: 'Error obteniendo inventario periférico',
-      });
+    res.status(500).json({
+      success: false,
+      message: 'Error obteniendo inventario periférico',
+    });
   }
 });
 
@@ -1089,12 +1062,10 @@ app.get('/api/historial_asignaciones', requireAuth, (req, res) => {
     (err, rows) => {
       if (err) {
         console.error('❌ Error obteniendo historial asignaciones:', err);
-        return res
-          .status(500)
-          .json({
-            success: false,
-            message: 'Error obteniendo historial asignaciones',
-          });
+        return res.status(500).json({
+          success: false,
+          message: 'Error obteniendo historial asignaciones',
+        });
       }
       res.json({ success: true, data: rows });
     }
@@ -2052,6 +2023,11 @@ if (require.main === module) {
     .then(() => {
       console.log('📦 Sistema de préstamos inicializado');
       return initializeVacacionesSystem();
+    })
+    .then(() => {
+      return analyticsDB.createInventoryTables().then(() => {
+        console.log('🦆 Tablas de DuckDB verificadas');
+      });
     })
     .catch((err) => {
       console.error('❌ Error inicializando el sistema:', err);


### PR DESCRIPTION
## Summary
- add `database/duckdb.js` to manage the analytics DuckDB database
- create inventory tables when the server boots
- initialize DuckDB tables during server start

## Testing
- `npx eslint . --fix` *(fails: ESLint couldn't find an eslint.config.js)*
- `npx prettier --write database/duckdb.js server.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864dfce57dc832a8ccc8fc894a3ba44