### PR TITLE
Ensure SESSION_SECRET is required

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,13 @@ if (!HAS_DATABASE_URL) {
 const app = express();
 const PORT = process.env.PORT || 5000;
 
+if (!process.env.SESSION_SECRET) {
+  console.error(
+    '❌ La variable de entorno SESSION_SECRET es requerida para la seguridad de las sesiones.'
+  );
+  process.exit(1);
+}
+
 function broadcast(event, data) {
   if (!wss) return;
   const message = JSON.stringify({ event, data });
@@ -45,7 +52,7 @@ app.use('/attached_assets', express.static('attached_assets')); // Para servir v
 // Configurar sesiones
 app.use(
   session({
-    secret: process.env.SESSION_SECRET || 'mi-secreto-super-seguro-123',
+    secret: process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
     cookie: {


### PR DESCRIPTION
## Summary
- check for SESSION_SECRET at startup
- remove insecure fallback secret

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; DuckDB Database is not a constructor)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run format:check` *(fails: SyntaxError in database/limpiar_usuarios_prueba.js)*

------
https://chatgpt.com/codex/tasks/task_e_6864f4a79804832aafaed074ed6fb3ff