### PR TITLE
Normalize API paths

### DIFF
--- a/server.js
+++ b/server.js
@@ -1007,32 +1007,6 @@ app.delete('/api/departamentos/:id', requireAuth, async (req, res) => {
   }
 });
 
-// Endpoints de solo lectura para el panel de control
-app.get('/api/inventario_principal', requireAuth, async (req, res) => {
-  try {
-    const data = await db.getInventarioPrincipal();
-    res.json({ success: true, data });
-  } catch (error) {
-    console.error('❌ Error obteniendo inventario principal:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Error obteniendo inventario principal',
-    });
-  }
-});
-
-app.get('/api/inventario_periferico', requireAuth, async (req, res) => {
-  try {
-    const data = await db.getInventarioPeriferico();
-    res.json({ success: true, data });
-  } catch (error) {
-    console.error('❌ Error obteniendo inventario periférico:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Error obteniendo inventario periférico',
-    });
-  }
-});
 
 app.get('/api/configuracion', requireAuth, (req, res) => {
   db.db.all('SELECT * FROM configuracion', [], (err, rows) => {
@@ -1941,29 +1915,6 @@ app.get('/api/empleados-completos', requireAuth, async (req, res) => {
       success: false,
       message: 'Error interno del servidor: ' + error.message,
     });
-  }
-});
-
-// Obtener todos los empleados básico
-app.get('/api/empleados', requireAuth, async (req, res) => {
-  try {
-    console.log('🔍 Obteniendo empleados desde la base de datos...');
-    const empleados = await db.getEmpleadosCompletos();
-    console.log(`✅ Obtenidos ${empleados.length} empleados`);
-    // Transformar datos para compatibilidad con frontend
-    const empleadosFormateados = empleados.map((emp) => ({
-      ...emp,
-      departamento:
-        emp.departamento_nombre || emp.departamento || 'Sin departamento',
-    }));
-    console.log('✅ Datos transformados, enviando respuesta...');
-    res.json(empleadosFormateados);
-  } catch (error) {
-    console.error('❌ Error obteniendo empleados:', error.message);
-    console.error('❌ Stack trace:', error.stack);
-    res
-      .status(500)
-      .json({ error: 'Error obteniendo empleados', details: error.message });
   }
 });
 

--- a/tests/departamentos.test.js
+++ b/tests/departamentos.test.js
@@ -112,14 +112,14 @@ describe('Panel control inventario endpoints', () => {
     jest.clearAllMocks();
   });
 
-  test('GET /api/inventario_principal returns inventory list', async () => {
-    const res = await request(app).get('/api/inventario_principal');
+  test('GET /api/inventario-principal returns inventory list', async () => {
+    const res = await request(app).get('/api/inventario-principal');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ success: true, data: [{ id: 'p1' }] });
   });
 
-  test('GET /api/inventario_periferico returns inventory list', async () => {
-    const res = await request(app).get('/api/inventario_periferico');
+  test('GET /api/inventario-periferico returns inventory list', async () => {
+    const res = await request(app).get('/api/inventario-periferico');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       success: true,


### PR DESCRIPTION
## Summary
- remove duplicate underscore routes in `server.js`
- use hyphenated paths in inventory tests

## Testing
- `npm test` *(fails: jest-environment-jsdom missing; duckdb not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_6864f5c3eed8832a9938efd024d494b3