### PR TITLE
Fix DuckDB initialization

### DIFF
--- a/database/duckdb.js
+++ b/database/duckdb.js
@@ -31,6 +31,7 @@ async function createInventoryTables() {
         id TEXT PRIMARY KEY,
         nombre TEXT NOT NULL
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_departamentos_id ON departamentos(id)`,
     `CREATE TABLE IF NOT EXISTS empleados (
         id TEXT PRIMARY KEY,
         placa TEXT UNIQUE,

--- a/server.js
+++ b/server.js
@@ -12,16 +12,7 @@ const analyticsDB = require('./database/duckdb');
 
 let wss; // WebSocket server (solo cuando se ejecuta directamente)
 
-// Verificar si se proporcionó la cadena de conexión a PostgreSQL
-const HAS_DATABASE_URL = Boolean(process.env.DATABASE_URL);
-if (!HAS_DATABASE_URL) {
-  console.error(
-    '⚠️  DATABASE_URL no está definido. Se omitirá la inicialización de PostgreSQL y se usará únicamente SQLite.'
-  );
-} else {
-  console.log('🔌 Conexión de PostgreSQL detectada a través de DATABASE_URL');
-  // Aquí se inicializaría PostgreSQL cuando esté disponible
-}
+
 
 const app = express();
 const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
## Summary
- create unique index on `departamentos.id` to satisfy FK requirements
- remove leftover PostgreSQL initialization message

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865061b7924832aa0b4007822ae3b60