### PR TITLE
Add inventory CRUD support

### DIFF
--- a/database/config.js
+++ b/database/config.js
@@ -612,6 +612,206 @@ class Database {
     });
   }
 
+  // Crear equipo principal
+  createEquipoPrincipal(data) {
+    return new Promise((resolve, reject) => {
+      const id = crypto.randomUUID();
+      const query = `
+                INSERT INTO inventario_principal (
+                    id, nombre, marca, modelo, serie, categoria, subcategoria,
+                    estado, condicion, tipo_adquisicion, id_departamento_asignado,
+                    ubicacion_especifica, responsable_actual, fecha_creacion,
+                    fecha_adquisicion, detalles
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `;
+      const values = [
+        id,
+        data.nombre,
+        data.marca,
+        data.modelo,
+        data.serie || null,
+        data.categoria,
+        data.subcategoria || null,
+        data.estado,
+        data.condicion,
+        data.tipoAdquisicion,
+        data.departamento,
+        data.ubicacion,
+        data.responsable,
+        new Date().toISOString(),
+        data.fechaAdquisicion || null,
+        data.detalles || null,
+      ];
+
+      this.db.run(query, values, function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ id });
+        }
+      });
+    });
+  }
+
+  // Actualizar equipo principal
+  updateEquipoPrincipal(id, data) {
+    return new Promise((resolve, reject) => {
+      const query = `
+                UPDATE inventario_principal SET
+                    nombre = ?, marca = ?, modelo = ?, serie = ?,
+                    categoria = ?, subcategoria = ?, estado = ?, condicion = ?,
+                    tipo_adquisicion = ?, id_departamento_asignado = ?,
+                    ubicacion_especifica = ?, responsable_actual = ?,
+                    fecha_adquisicion = ?, detalles = ?
+                WHERE id = ?
+            `;
+
+      const values = [
+        data.nombre,
+        data.marca,
+        data.modelo,
+        data.serie || null,
+        data.categoria,
+        data.subcategoria || null,
+        data.estado,
+        data.condicion,
+        data.tipoAdquisicion,
+        data.departamento,
+        data.ubicacion,
+        data.responsable,
+        data.fechaAdquisicion || null,
+        data.detalles || null,
+        id,
+      ];
+
+      this.db.run(query, values, function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ changes: this.changes });
+        }
+      });
+    });
+  }
+
+  // Eliminar equipo principal
+  deleteEquipoPrincipal(id) {
+    return new Promise((resolve, reject) => {
+      const query = 'DELETE FROM inventario_principal WHERE id = ?';
+      this.db.run(query, [id], function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ changes: this.changes });
+        }
+      });
+    });
+  }
+
+  // Crear periférico
+  createPeriferico(data) {
+    return new Promise((resolve, reject) => {
+      const id = crypto.randomUUID();
+      const query = `
+                INSERT INTO inventario_periferico (
+                    id_periferico, nombre_periferico, marca_periferico,
+                    modelo_periferico, serie_periferico, estado_periferico,
+                    condicion_periferico, tipo_adquisicion_periferico,
+                    id_departamento_asignado_periferico,
+                    ubicacion_especifica_periferico,
+                    responsable_actual_periferico,
+                    fecha_creacion_periferico, fecha_adquisicion_periferico,
+                    detalles_periferico, id_inventario_principal
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `;
+
+      const values = [
+        id,
+        data.nombre,
+        data.marca,
+        data.modelo,
+        data.serie || null,
+        data.estado,
+        data.condicion,
+        data.tipoAdquisicion,
+        data.departamento,
+        data.ubicacion,
+        data.responsable,
+        new Date().toISOString(),
+        data.fechaAdquisicion || null,
+        data.detalles || null,
+        data.equipoPrincipalId,
+      ];
+
+      this.db.run(query, values, function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ id });
+        }
+      });
+    });
+  }
+
+  // Actualizar periférico
+  updatePeriferico(id, data) {
+    return new Promise((resolve, reject) => {
+      const query = `
+                UPDATE inventario_periferico SET
+                    nombre_periferico = ?, marca_periferico = ?,
+                    modelo_periferico = ?, serie_periferico = ?,
+                    estado_periferico = ?, condicion_periferico = ?,
+                    tipo_adquisicion_periferico = ?,
+                    id_departamento_asignado_periferico = ?,
+                    ubicacion_especifica_periferico = ?,
+                    responsable_actual_periferico = ?,
+                    fecha_adquisicion_periferico = ?,
+                    detalles_periferico = ?,
+                    id_inventario_principal = ?
+                WHERE id_periferico = ?
+            `;
+
+      const values = [
+        data.nombre,
+        data.marca,
+        data.modelo,
+        data.serie || null,
+        data.estado,
+        data.condicion,
+        data.tipoAdquisicion,
+        data.departamento,
+        data.ubicacion,
+        data.responsable,
+        data.fechaAdquisicion || null,
+        data.detalles || null,
+        data.equipoPrincipalId,
+        id,
+      ];
+
+      this.db.run(query, values, function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ changes: this.changes });
+        }
+      });
+    });
+  }
+
+  // Eliminar periférico
+  deletePeriferico(id) {
+    return new Promise((resolve, reject) => {
+      const query = 'DELETE FROM inventario_periferico WHERE id_periferico = ?';
+      this.db.run(query, [id], function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ changes: this.changes });
+        }
+      });
+    });
+  }
+
   getEmpleados() {
     return new Promise((resolve, reject) => {
       const query = `

--- a/public/inventario/inventario.js
+++ b/public/inventario/inventario.js
@@ -3,8 +3,9 @@ document.addEventListener('DOMContentLoaded', function () {
   // Variables globales
   let equipos = [];
   let perifericos = [];
-  const API_PRINCIPAL = '/api/inventario-principal';
-  const API_PERIFERICOS = '/api/inventario-periferico';
+  // Endpoints CRUD de inventario
+  const API_INVENTARIO_PRINCIPAL = '/api/inventario-principal';
+  const API_INVENTARIO_PERIFERICO = '/api/inventario-periferico';
   let currentView = 'principal';
   let equipoPrincipalSeleccionado = null;
 
@@ -48,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   async function loadEquipos() {
     try {
-      const res = await fetch(API_PRINCIPAL);
+      const res = await fetch(API_INVENTARIO_PRINCIPAL);
       const data = await res.json();
       equipos = data.inventario || data.data || [];
     } catch (err) {
@@ -59,7 +60,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   async function loadPerifericos() {
     try {
-      const res = await fetch(API_PERIFERICOS);
+      const res = await fetch(API_INVENTARIO_PERIFERICO);
       const data = await res.json();
       perifericos = data.inventario || data.data || [];
     } catch (err) {
@@ -71,8 +72,8 @@ document.addEventListener('DOMContentLoaded', function () {
   async function deleteItem(id, type) {
     const url =
       type === 'principal'
-        ? `${API_PRINCIPAL}/${id}`
-        : `${API_PERIFERICOS}/${id}`;
+        ? `${API_INVENTARIO_PRINCIPAL}/${id}`
+        : `${API_INVENTARIO_PERIFERICO}/${id}`;
     const res = await fetch(url, { method: 'DELETE' });
     if (!res.ok) {
       throw new Error('Error eliminando elemento');
@@ -792,7 +793,10 @@ document.addEventListener('DOMContentLoaded', function () {
     // Guardar o actualizar el item en el servidor
 
     let method = id ? 'PUT' : 'POST';
-    let url = type === 'principal' ? API_PRINCIPAL : API_PERIFERICOS;
+    let url =
+      type === 'principal'
+        ? API_INVENTARIO_PRINCIPAL
+        : API_INVENTARIO_PERIFERICO;
     if (id) url += `/${id}`;
 
     try {

--- a/server.js
+++ b/server.js
@@ -866,6 +866,100 @@ app.get('/api/inventario-completo', requireAuth, async (req, res) => {
   }
 });
 
+// Crear equipo principal
+app.post('/api/inventario-principal', requireAuth, async (req, res) => {
+  try {
+    await db.beginTransaction();
+    const result = await db.createEquipoPrincipal(req.body);
+    await db.commitTransaction();
+    res.status(201).json({
+      success: true,
+      message: 'Equipo principal creado',
+      equipoId: result.id,
+    });
+  } catch (error) {
+    await db.rollbackTransaction();
+    console.error('❌ Error creando equipo principal:', error);
+    res.status(500).json({ success: false, message: 'Error creando equipo principal' });
+  }
+});
+
+// Actualizar equipo principal
+app.put('/api/inventario-principal/:id', requireAuth, async (req, res) => {
+  try {
+    await db.beginTransaction();
+    const result = await db.updateEquipoPrincipal(req.params.id, req.body);
+    await db.commitTransaction();
+    if (result.changes === 0) {
+      return res.status(404).json({ success: false, message: 'Equipo principal no encontrado' });
+    }
+    res.json({ success: true, message: 'Equipo principal actualizado' });
+  } catch (error) {
+    await db.rollbackTransaction();
+    console.error('❌ Error actualizando equipo principal:', error);
+    res.status(500).json({ success: false, message: 'Error actualizando equipo principal' });
+  }
+});
+
+// Eliminar equipo principal
+app.delete('/api/inventario-principal/:id', requireAuth, async (req, res) => {
+  try {
+    const result = await db.deleteEquipoPrincipal(req.params.id);
+    if (result.changes === 0) {
+      return res.status(404).json({ success: false, message: 'Equipo principal no encontrado' });
+    }
+    res.json({ success: true, message: 'Equipo principal eliminado' });
+  } catch (error) {
+    console.error('❌ Error eliminando equipo principal:', error);
+    res.status(500).json({ success: false, message: 'Error eliminando equipo principal' });
+  }
+});
+
+// Crear periférico
+app.post('/api/inventario-periferico', requireAuth, async (req, res) => {
+  try {
+    await db.beginTransaction();
+    const result = await db.createPeriferico(req.body);
+    await db.commitTransaction();
+    res.status(201).json({ success: true, message: 'Periférico creado', perifericoId: result.id });
+  } catch (error) {
+    await db.rollbackTransaction();
+    console.error('❌ Error creando periférico:', error);
+    res.status(500).json({ success: false, message: 'Error creando periférico' });
+  }
+});
+
+// Actualizar periférico
+app.put('/api/inventario-periferico/:id', requireAuth, async (req, res) => {
+  try {
+    await db.beginTransaction();
+    const result = await db.updatePeriferico(req.params.id, req.body);
+    await db.commitTransaction();
+    if (result.changes === 0) {
+      return res.status(404).json({ success: false, message: 'Periférico no encontrado' });
+    }
+    res.json({ success: true, message: 'Periférico actualizado' });
+  } catch (error) {
+    await db.rollbackTransaction();
+    console.error('❌ Error actualizando periférico:', error);
+    res.status(500).json({ success: false, message: 'Error actualizando periférico' });
+  }
+});
+
+// Eliminar periférico
+app.delete('/api/inventario-periferico/:id', requireAuth, async (req, res) => {
+  try {
+    const result = await db.deletePeriferico(req.params.id);
+    if (result.changes === 0) {
+      return res.status(404).json({ success: false, message: 'Periférico no encontrado' });
+    }
+    res.json({ success: true, message: 'Periférico eliminado' });
+  } catch (error) {
+    console.error('❌ Error eliminando periférico:', error);
+    res.status(500).json({ success: false, message: 'Error eliminando periférico' });
+  }
+});
+
 // Obtener departamentos
 app.get('/api/departamentos', requireAuth, async (req, res) => {
   try {

--- a/tests/inventario_crud.test.js
+++ b/tests/inventario_crud.test.js
@@ -1,0 +1,122 @@
+const request = require('supertest');
+
+// Mocks for database module
+const mockCreateEquipoPrincipal = jest.fn(() => Promise.resolve({ id: 'eq1' }));
+const mockUpdateEquipoPrincipal = jest.fn(() => Promise.resolve({ changes: 1 }));
+const mockDeleteEquipoPrincipal = jest.fn(() => Promise.resolve({ changes: 1 }));
+const mockCreatePeriferico = jest.fn(() => Promise.resolve({ id: 'per1' }));
+const mockUpdatePeriferico = jest.fn(() => Promise.resolve({ changes: 1 }));
+const mockDeletePeriferico = jest.fn(() => Promise.resolve({ changes: 1 }));
+const mockBeginTransaction = jest.fn(() => Promise.resolve());
+const mockCommitTransaction = jest.fn(() => Promise.resolve());
+const mockRollbackTransaction = jest.fn(() => Promise.resolve());
+
+jest.mock('../database/config', () => {
+  return jest.fn().mockImplementation(() => ({
+    db: { get: jest.fn(), all: jest.fn() },
+    connect: jest.fn(() => Promise.resolve()),
+    beginTransaction: mockBeginTransaction,
+    commitTransaction: mockCommitTransaction,
+    rollbackTransaction: mockRollbackTransaction,
+    createEquipoPrincipal: mockCreateEquipoPrincipal,
+    updateEquipoPrincipal: mockUpdateEquipoPrincipal,
+    deleteEquipoPrincipal: mockDeleteEquipoPrincipal,
+    createPeriferico: mockCreatePeriferico,
+    updatePeriferico: mockUpdatePeriferico,
+    deletePeriferico: mockDeletePeriferico,
+    getInventarioPrincipal: jest.fn(() => Promise.resolve([])),
+    getInventarioPeriferico: jest.fn(() => Promise.resolve([])),
+    getInventarioCompleto: jest.fn(() => Promise.resolve([])),
+    getUser: jest.fn(),
+    logAccess: jest.fn(),
+  }));
+});
+
+jest.mock('../database/prestamos', () => {
+  return jest.fn().mockImplementation(() => ({
+    conectar: jest.fn(() => Promise.resolve()),
+  }));
+});
+
+jest.mock('../database/vacaciones', () => {
+  return jest.fn().mockImplementation(() => ({
+    actualizarEstadosVacaciones: jest.fn(),
+  }));
+});
+
+jest.mock('../database/duckdb', () => ({
+  createInventoryTables: jest.fn(),
+  listTables: jest.fn(() => Promise.resolve([])),
+  getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+}));
+
+process.env.SESSION_SECRET = 'test';
+
+const app = require('../server');
+app.request.session = { user: { id: 'test', rol: 'admin' } };
+
+describe('Inventario CRUD endpoints', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('POST /api/inventario-principal creates item', async () => {
+    const res = await request(app)
+      .post('/api/inventario-principal')
+      .send({ nombre: 'pc' });
+    expect(res.status).toBe(201);
+    expect(mockCreateEquipoPrincipal).toHaveBeenCalled();
+    expect(res.body).toEqual({
+      success: true,
+      message: 'Equipo principal creado',
+      equipoId: 'eq1',
+    });
+  });
+
+  test('PUT /api/inventario-principal/:id updates item', async () => {
+    const res = await request(app)
+      .put('/api/inventario-principal/abc')
+      .send({ nombre: 'upd' });
+    expect(res.status).toBe(200);
+    expect(mockUpdateEquipoPrincipal).toHaveBeenCalledWith('abc', {
+      nombre: 'upd',
+    });
+    expect(res.body).toEqual({ success: true, message: 'Equipo principal actualizado' });
+  });
+
+  test('DELETE /api/inventario-principal/:id deletes item', async () => {
+    const res = await request(app).delete('/api/inventario-principal/abc');
+    expect(res.status).toBe(200);
+    expect(mockDeleteEquipoPrincipal).toHaveBeenCalledWith('abc');
+    expect(res.body).toEqual({ success: true, message: 'Equipo principal eliminado' });
+  });
+
+  test('POST /api/inventario-periferico creates item', async () => {
+    const res = await request(app)
+      .post('/api/inventario-periferico')
+      .send({ nombre: 'per' });
+    expect(res.status).toBe(201);
+    expect(mockCreatePeriferico).toHaveBeenCalled();
+    expect(res.body).toEqual({
+      success: true,
+      message: 'Periférico creado',
+      perifericoId: 'per1',
+    });
+  });
+
+  test('PUT /api/inventario-periferico/:id updates item', async () => {
+    const res = await request(app)
+      .put('/api/inventario-periferico/xyz')
+      .send({ nombre: 'per' });
+    expect(res.status).toBe(200);
+    expect(mockUpdatePeriferico).toHaveBeenCalledWith('xyz', { nombre: 'per' });
+    expect(res.body).toEqual({ success: true, message: 'Periférico actualizado' });
+  });
+
+  test('DELETE /api/inventario-periferico/:id deletes item', async () => {
+    const res = await request(app).delete('/api/inventario-periferico/xyz');
+    expect(res.status).toBe(200);
+    expect(mockDeletePeriferico).toHaveBeenCalledWith('xyz');
+    expect(res.body).toEqual({ success: true, message: 'Periférico eliminado' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement creation, update and deletion helpers in DB layer for principal equipment and peripherals
- expose POST/PUT/DELETE API routes for inventory items
- update frontend inventory module to use these endpoints
- add test coverage for new endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865e69dfe24832ab3636120fddb2039