### PR TITLE
Add DuckDB initialization helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,16 @@ SESSION_SECRET=tu_clave_secreta_aqui_para_sesiones_seguras
 
 Antes de iniciar por primera vez, verifica que exista el directorio `attached_assets` en la raíz del proyecto. Allí se almacena la base de datos SQLite. Si no está presente, los scripts lo crearán automáticamente.
 
-Si has ejecutado el proyecto anteriormente, elimina el archivo `attached_assets/analytics.db` antes de la primera sincronización. Esto permite que `createInventoryTables` genere las tablas con todas sus restricciones de forma correcta.
+Si has ejecutado el proyecto anteriormente, elimina el archivo `attached_assets/analytics.db` antes de la primera sincronización. Esto permite que `initializeDuckDB` cree las tablas con todas sus restricciones de forma correcta.
 
 4. Inicializar Base de Datos
    Bash
 
-# El sistema inicializa automáticamente al ejecutar
+# El servidor inicializa automáticamente la base de datos al iniciar
 
-npm start 5. Acceder al Sistema
+npm start
+
+5. Acceder al Sistema
 http://localhost:3000
 👤 Usuarios de Acceso
 Usuarios de Prueba Disponibles

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const http = require('http');
 const WebSocket = require('ws');
 const Database = require('./database/config');
 const VacacionesManager = require('./database/vacaciones');
-const analyticsDB = require('./database/duckdb');
+const { connection: analyticsDB, initializeDuckDB } = require('./database/duckdb');
 
 let wss; // WebSocket server (solo cuando se ejecuta directamente)
 
@@ -2090,8 +2090,8 @@ if (require.main === module) {
       return initializeVacacionesSystem();
     })
     .then(() => {
-      return analyticsDB.createInventoryTables().then(() => {
-        console.log('🦆 Tablas de DuckDB verificadas');
+      return initializeDuckDB().then(() => {
+        console.log('🦆 DuckDB inicializado');
       });
     })
     .catch((err) => {

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -28,9 +28,12 @@ jest.mock('../database/vacaciones', () => {
 });
 
 jest.mock('../database/duckdb', () => ({
-  createInventoryTables: jest.fn(),
-  listTables: jest.fn(() => Promise.resolve([])),
-  getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  connection: {
+    createInventoryTables: jest.fn(),
+    listTables: jest.fn(() => Promise.resolve([])),
+    getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  },
+  initializeDuckDB: jest.fn(),
 }));
 
 process.env.SESSION_SECRET = 'test';

--- a/tests/departamentos.test.js
+++ b/tests/departamentos.test.js
@@ -56,9 +56,12 @@ jest.mock('../database/vacaciones', () => {
 });
 
 jest.mock('../database/duckdb', () => ({
-  createInventoryTables: jest.fn(),
-  listTables: jest.fn(() => Promise.resolve([])),
-  getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  connection: {
+    createInventoryTables: jest.fn(),
+    listTables: jest.fn(() => Promise.resolve([])),
+    getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  },
+  initializeDuckDB: jest.fn(),
 }));
 
 process.env.SESSION_SECRET = 'test';

--- a/tests/empleados_route.test.js
+++ b/tests/empleados_route.test.js
@@ -23,9 +23,12 @@ jest.mock('../database/vacaciones', () => {
 });
 
 jest.mock('../database/duckdb', () => ({
-  createInventoryTables: jest.fn(),
-  listTables: jest.fn(() => Promise.resolve([])),
-  getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  connection: {
+    createInventoryTables: jest.fn(),
+    listTables: jest.fn(() => Promise.resolve([])),
+    getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  },
+  initializeDuckDB: jest.fn(),
 }));
 
 process.env.SESSION_SECRET = 'test';

--- a/tests/inventario_crud.test.js
+++ b/tests/inventario_crud.test.js
@@ -45,9 +45,12 @@ jest.mock('../database/vacaciones', () => {
 });
 
 jest.mock('../database/duckdb', () => ({
-  createInventoryTables: jest.fn(),
-  listTables: jest.fn(() => Promise.resolve([])),
-  getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  connection: {
+    createInventoryTables: jest.fn(),
+    listTables: jest.fn(() => Promise.resolve([])),
+    getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  },
+  initializeDuckDB: jest.fn(),
 }));
 
 process.env.SESSION_SECRET = 'test';

--- a/tests/usuarios.test.js
+++ b/tests/usuarios.test.js
@@ -37,9 +37,12 @@ jest.mock('../database/vacaciones', () => {
 });
 
 jest.mock('../database/duckdb', () => ({
-  createInventoryTables: jest.fn(),
-  listTables: jest.fn(() => Promise.resolve([])),
-  getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  connection: {
+    createInventoryTables: jest.fn(),
+    listTables: jest.fn(() => Promise.resolve([])),
+    getTablePreview: jest.fn(() => Promise.resolve({ columns: [], rows: [] })),
+  },
+  initializeDuckDB: jest.fn(),
 }));
 
 process.env.SESSION_SECRET = 'test';


### PR DESCRIPTION
## Summary
- create `initializeDuckDB` to open the database and create tables
- export the connection and the initializer
- await `initializeDuckDB` from the server on startup
- adjust tests for new export
- mention new initialization step in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865ef08a2ec832a9e75ef782f7ac6f1