### PR TITLE
Fix missing SESSION_SECRET error and exit

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,9 +17,7 @@ const app = express();
 const PORT = process.env.PORT || 5001;
 
 if (!process.env.SESSION_SECRET) {
-  console.error(
-    'âŒ La variable de entorno SESSION_SECRET es requerida para la seguridad de las sesiones.'
-  );
+  console.error('La variable de entorno SESSION_SECRET es requerida para la seguridad de las sesiones.');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- repair corrupted message for missing `SESSION_SECRET`
- ensure server exits when initialization fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b76d9c4a88330813a01b3f4664fb1