### PR TITLE
Remove DuckDB docs

### DIFF
--- a/INVENTARIO_SETUP.md
+++ b/INVENTARIO_SETUP.md
@@ -9,7 +9,6 @@
 
 ### Principales
 
-- `@duckdb/node-api`: ^0.10.0 (Cliente Node.js para DuckDB)
 - `superagent`: ^9.0.0 (Cliente HTTP para Node.js)
 
 ## Estructura de Base de Datos
@@ -70,16 +69,15 @@ CREATE TABLE perifericos (
 
 1. Instalar dependencias:
 
-   ```bash
-   npm install @duckdb/node-api superagent@latest
-   ```
+```bash
+npm install superagent@latest
+```
 
 2. Crear archivo de configuración `.env` en la raíz del proyecto:
 
    ```env
    # Configuración de Base de Datos
-   DB_PATH=./attached_assets/kilo.db
-   DUCKDB_PATH=./attached_assets/analytics.db
+    DB_PATH=./attached_assets/kilo.db
 
    # Configuración del Servidor
    PORT=3000
@@ -104,6 +102,5 @@ npm run dev
 
 ### 2025-07-01
 
-- Instalado @duckdb/node-api
 - Actualizado superagent a la versión 9.0.0+
 - Configurada la estructura inicial de la base de datos

--- a/README.md
+++ b/README.md
@@ -87,9 +87,7 @@ SESSION_SECRET=tu_clave_secreta_aqui_para_sesiones_seguras
 
 (Asegúrate de reemplazar el valor con tu propia clave segura)
 
-Antes de iniciar por primera vez, verifica que exista el directorio `attached_assets` en la raíz del proyecto. Allí se almacena la base de datos SQLite. Si no está presente, los scripts lo crearán automáticamente.
-
-Si has ejecutado el proyecto anteriormente, elimina el archivo `attached_assets/analytics.db` antes de la primera sincronización. Esto permite que `initializeDuckDB` cree las tablas con todas sus restricciones de forma correcta.
+Antes de iniciar por primera vez, verifica que exista el directorio `attached_assets` en la raíz del proyecto. Allí se almacena la base de datos SQLite `kilo.db`. Si no está presente, los scripts la crearán automáticamente.
 
 4. Inicializar Base de Datos
    Bash


### PR DESCRIPTION
## Summary
- cleanup docs to only mention `kilo.db`
- drop DuckDB instructions from inventory setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b9a472d6483308147ad41463ae708